### PR TITLE
[BUGFIX] Swap import order

### DIFF
--- a/dsbot/management/commands/bot.py
+++ b/dsbot/management/commands/bot.py
@@ -7,9 +7,9 @@ from dsbot.client import BotClient
 from dsbot.conf import settings
 
 try:
-    from importlib.metadata import entry_points
-except ImportError:
     from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 
 class Command(BaseCommand):

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     aiohttp
     celery
     slack-sdk>=3.5.1
-    importlib-metadata>=1.0 ;python_version < "3.8"
+    importlib-metadata>=1.0 ;python_version < "3.10"
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
We depend on the version of entry_points that allows filter by group, so we want to both ensure that we require the right version, but that we also import the correct version.